### PR TITLE
Pm 3343 move additional metadata fields management to summary serializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,11 @@ Changelog
 1.0a12 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Moved management of additional `metadata_fields` from the `SearchGet` service
+  to the `DefaultJSONSummarySerializer` created for that, it will override
+  the default `plone.restapi` `DefaultJSONSummarySerializer` and add
+  `id` and `UID` by default to the results.
+  [gbastien]
 
 1.0a11 (2020-09-10)
 -------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -207,3 +207,8 @@ collective.z3cform.select2 = 1.4.1
 eea.faceted.vocabularies = 5.3
 eea.facetednavigation = 9.2
 eea.jquery = 9.3
+
+# Required by:
+# collective.fingerpointing
+zc.lockfile = 1.2.1
+file-read-backwards = 1.2.2

--- a/src/imio/restapi/serializer/base.py
+++ b/src/imio/restapi/serializer/base.py
@@ -49,7 +49,7 @@ class DefaultJSONSummarySerializer(summary.DefaultJSONSummarySerializer):
 
     @property
     def _additional_fields(self):
-        """By default add 'UID' to returned data."""
+        """By default add 'id' and 'UID' to returned data."""
         return ["id", "UID"]
 
     def _set_metadata_fields(self):

--- a/src/imio/restapi/serializer/base.py
+++ b/src/imio/restapi/serializer/base.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
 
 from Acquisition import aq_inner
-from plone.restapi.serializer import dxcontent
-from plone.restapi.interfaces import ISerializeToJson
-from zope.component import adapter
-from zope.interface import implementer
+from imio.restapi.interfaces import IImioRestapiLayer
+from imio.restapi.utils import listify
+from Products.ZCatalog.interfaces import ICatalogBrain
+from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
-from imio.restapi.interfaces import IImioRestapiLayer
-from plone import api
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.serializer import dxcontent
+from plone.restapi.serializer import summary
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
 
 
 @implementer(ISerializeToJson)
@@ -35,3 +40,28 @@ def get_relative_path(context):
 
     relative_path = context.getPhysicalPath()[len(portal.getPhysicalPath()):]
     return "/{}".format("/".join(relative_path))
+
+
+@implementer(ISerializeToJsonSummary)
+@adapter(ICatalogBrain, Interface)
+class DefaultJSONSummarySerializer(summary.DefaultJSONSummarySerializer):
+    """Formalize management of defining extra metadata_fields in the serializer."""
+
+    @property
+    def _additional_fields(self):
+        """By default add 'UID' to returned data."""
+        return ["id", "UID"]
+
+    def _set_metadata_fields(self):
+        """Must be set in request.form."""
+        form = self.request.form
+        # manage metadata_fields
+        additional_metadata_fields = listify(form.get("metadata_fields", []))
+        additional_metadata_fields += self._additional_fields
+        form["metadata_fields"] = additional_metadata_fields
+
+    def __call__(self):
+        """ """
+        self._set_metadata_fields()
+        result = super(DefaultJSONSummarySerializer, self).__call__()
+        return result

--- a/src/imio/restapi/serializer/configure.zcml
+++ b/src/imio/restapi/serializer/configure.zcml
@@ -6,6 +6,7 @@
 
   <adapter factory=".base.SerializeToJson" />
   <adapter factory=".base.SerializeFolderToJson" />
+  <adapter factory=".base.DefaultJSONSummarySerializer" />
   <adapter factory=".rest_link.SerializeRestLinkToJson" />
 
 </configure>

--- a/src/imio/restapi/services/search.py
+++ b/src/imio/restapi/services/search.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from imio.helpers.content import uuidsToObjects
-from imio.restapi.utils import listify
 from plone.app.querystring.queryparser import parseFormquery
 from plone.restapi.search.handler import SearchHandler
 from plone.restapi.search.utils import unflatten_dotted_dict
@@ -11,13 +10,7 @@ from plone.restapi.services.search.get import SearchGet as BaseSearchGet
 class SearchGet(BaseSearchGet):
     """Base SearchGet, handles :
        - using a base_search_uid (Collection UID) as base query;
-       - adding additional parameters to query;
-       - formalize metadata_fields."""
-
-    @property
-    def _additional_fields(self):
-        """By default add 'UID' to returned data."""
-        return ["UID"]
+       - adding additional parameters to query."""
 
     def _set_query_before_hook(self):
         """Manipulate query before hook."""
@@ -51,14 +44,6 @@ class SearchGet(BaseSearchGet):
            WARNING plone.restapi.search.query No such index: 'my_custom_parameter'"""
         query.pop("my_custom_parameter", None)
 
-    def _set_metadata_fields(self):
-        """Must be set in request.form."""
-        form = self.request.form
-        # manage metadata_fields
-        additional_metadata_fields = listify(form.get("metadata_fields", []))
-        additional_metadata_fields += self._additional_fields
-        form["metadata_fields"] = additional_metadata_fields
-
     def _process_reply(self):
         """Easier to override if necessary to call various ways from reply method."""
         query = {}
@@ -70,8 +55,6 @@ class SearchGet(BaseSearchGet):
         query.update(self._set_query_after_hook())
         self._clean_query(query)
         query = unflatten_dotted_dict(query)
-
-        self._set_metadata_fields()
 
         return SearchHandler(self.context, self.request).search(query)
 

--- a/src/imio/restapi/tests/test_service_search.py
+++ b/src/imio/restapi/tests/test_service_search.py
@@ -29,3 +29,6 @@ class TestServiceSearchGet(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         json = response.json()
         self.assertEqual(json[u"items_total"], 12)
+        # "id" and "UID" are added to the default search result
+        self.assertTrue("UID" in json["items"][0])
+        self.assertTrue("id" in json["items"][0])


### PR DESCRIPTION
Salut @mpeeters 

ceci peut attendre semaine prochaine ;-)

On avait ajouté une gestion formelle de l'ajout de metadata_fields, cad les metadata ramenées dans le json lors de l'utilisation d'un SummarySerializer, notamment pour ajouter UID au résultat par défaut.

Ceci était fait dans le service @search, mais j'ai déplacé çà dans le serializer "summary" car c'est là que c'est géré dans plone.restapi et çà doit être géré là afin que pour un autre service qui utilise SummarySerializer çà fonctionne aussi.

J'ai implémenté çà dans plonemeeting.restapi et çà fonctionne.

Donc ici il s'agit juste du SummarySerializer de plone.restapi overridé par défaut et qui ajoute UID et id, soit on laisse la classe mais on commente le zcml, ou alors on laisse comme çà, dis moi ce que tu préfères.

Merci pour le review!

Gauthier

PS: SummarySerializer fonctionne par défaut sur des brains donc pour le surcharger, plutôt que l'adapter soit enregistré pour Interface/Interface, il est enregistré pour ICatalogBrain/Interface...