### PR TITLE
Added possibility to redefine the name of the `metadata_fields`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,11 +15,13 @@ Changelog
 - Require `plone.restapi<8` in `setup.py` as versions 8+ are only for Python3.
   [gbastien]
 
-- Added possibility to redefine the name of the `metadata_fields` form parameter
-  so it may be overrided by a subclass for example.
 - Fixed tests due to changes in `collective.documentgenerator` where
   the `ConfigurablePODTemplate` named `test_ods_template` is no more generable
   on type `Document`.
+  [gbastien]
+
+- Added possibility to redefine the name of the `metadata_fields` form parameter
+  so it may be overrided by a subclass for example.
   [gbastien]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,16 @@ Changelog
 
 - Avoid duplicates in `metadata_fields`.
   [gbastien]
+
 - In `@infos` if `PWD` env variable is not available, try to determinate instance
   path using the `INSTANCE_HOME` env variable.
   [gbastien]
+
 - Require `plone.restapi<8` in `setup.py` as versions 8+ are only for Python3.
+  [gbastien]
+
+- Added possibility to redefine the name of the `metadata_fields` form parameter
+  so it may be overrided by a subclass for example.
   [gbastien]
 
 

--- a/src/imio/restapi/serializer/base.py
+++ b/src/imio/restapi/serializer/base.py
@@ -2,7 +2,6 @@
 
 from Acquisition import aq_inner
 from imio.restapi.interfaces import IImioRestapiLayer
-from imio.restapi.utils import listify
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
@@ -61,14 +60,13 @@ class DefaultJSONSummarySerializer(summary.DefaultJSONSummarySerializer):
 
     def metadata_fields(self):
         """Override from plone.restapi to be able to change the metadata_fields name..."""
-        # XXX following line is replaced
+        # following line is replaced
         # additional_metadata_fields = self.request.form.get("metadata_fields", [])
         additional_metadata_fields = self.request.form.get(self._get_metadata_fields_name(), [])
         if not isinstance(additional_metadata_fields, list):
             additional_metadata_fields = [additional_metadata_fields]
-        # XXX begin custom additional metadata_fields
+        # following line is added, additional metadata_fields
         additional_metadata_fields += self._additional_fields
-        # XXX end custom additional metadata_fields
 
         additional_metadata_fields = set(additional_metadata_fields)
 

--- a/src/imio/restapi/serializer/base.py
+++ b/src/imio/restapi/serializer/base.py
@@ -66,6 +66,10 @@ class DefaultJSONSummarySerializer(summary.DefaultJSONSummarySerializer):
         additional_metadata_fields = self.request.form.get(self._get_metadata_fields_name(), [])
         if not isinstance(additional_metadata_fields, list):
             additional_metadata_fields = [additional_metadata_fields]
+        # XXX begin custom additional metadata_fields
+        additional_metadata_fields += self._additional_fields
+        # XXX end custom additional metadata_fields
+
         additional_metadata_fields = set(additional_metadata_fields)
 
         if "_all" in additional_metadata_fields:
@@ -77,19 +81,3 @@ class DefaultJSONSummarySerializer(summary.DefaultJSONSummarySerializer):
             additional_metadata_fields = fields_cache
 
         return DEFAULT_METADATA_FIELDS | additional_metadata_fields
-
-    def _set_metadata_fields(self):
-        """Must be set in request.form."""
-        metadata_fields_name = self._get_metadata_fields_name()
-        form = self.request.form
-        # manage metadata_fields
-        additional_metadata_fields = listify(form.get(metadata_fields_name, []))
-        additional_metadata_fields += self._additional_fields
-        # manage duplicates
-        form[metadata_fields_name] = list(set(additional_metadata_fields))
-
-    def __call__(self):
-        """ """
-        self._set_metadata_fields()
-        result = super(DefaultJSONSummarySerializer, self).__call__()
-        return result


### PR DESCRIPTION
 form parameter name so it may be overrided by a subclass for example.

See #PM-3369

Salut @mpeeters 
l'idée ici c'est de pouvoir redéfinir le nom de la variable "metadata_fields" trouvée dans request.form
On a un usecase de devoir passer ce metadata_fields pour 2 éléments différents sérializé dans la même requête, du coup dans PM on formalise la notion de "élément inclus supplémentaire" et on génère un "extra_include_category_metadata_fields", c'est donc pour utiliser ce nom là quand c'est nécessaire.

Je fait la surcharge dans imio.restapi car un jour (...) j'aimerais remettre la fonctionnalité de PM dans imio.restapi mais çà nécessitera encore du polish...

Par défaut çà ne change rien, mais malheureusement il faut surcharger la méthode "metadata_fields" de plone.restapi

Merci pour le review!

Gauthier