### PR TITLE
In `FolderPost` if an error occurs in `plone.restapi FolderPost`, stop and return the result immediately.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ log.html
 output.xml
 package.json
 pip-selfcheck.json
+pyvenv.cfg
 report.html
 .vscode/
 # excludes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@ Changelog
 
 - Override 'update' and 'workflow transition' to use the uid
   [vpiret]
-
+- In `FolderPost` if an error occurs in `plone.restapi FolderPost`,
+  stop and return the result immediately.
+  [gbastien]
 
 1.0a14 (2021-07-16)
 -------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -41,6 +41,7 @@ zopesvn = svn://svn.zope.org/repos/main/
 
 [sources]
 collective.documentgenerator = git ${remotes:collective}/collective.documentgenerator.git pushurl=${remotes:collective_push}/collective.documentgenerator.git
+imio.helpers = git ${remotes:imio}/imio.helpers.git pushurl=${remotes:imio_push}/imio.helpers.git
 Products.CPUtils = git ${remotes:imio}/Products.CPUtils.git pushurl=${remotes:imio_push}/Products.CPUtils.git
 
 
@@ -191,3 +192,7 @@ eea.jquery = 9.3
 # collective.fingerpointing
 zc.lockfile = 1.2.1
 file-read-backwards = 1.2.2
+
+# Required by:
+# imio.helpers, plone.api>1.9.1
+plone.api = 1.10.4

--- a/src/imio/restapi/services/add.py
+++ b/src/imio/restapi/services/add.py
@@ -101,6 +101,8 @@ class FolderPost(add.FolderPost):
             children = self.data.pop("__children__")
             self.request.set("BODY", json.dumps(self.data))
         result = super(FolderPost, self).reply()
+        if "error" in result:
+            return result
         self.wf_transitions(result)
         self._after_reply_hook(result)
         result["@warnings"] = self.warnings

--- a/src/imio/restapi/tests/test_service_add.py
+++ b/src/imio/restapi/tests/test_service_add.py
@@ -207,3 +207,23 @@ class TestFolderCreate(unittest.TestCase):
         brains = self.portal.portal_catalog(review_state="published")
         doc = brains[0].getObject()
         self.assertEqual(doc.UID(), json["__children__"][0]["UID"])
+
+    def test_folder_post_unauthorized(self):
+        plone_site = self.portal.portal_types["Plone Site"]
+        plone_site.filter_content_types = True
+        transaction.commit()
+        response = requests.post(
+            self.portal_url,
+            headers={"Accept": "application/json"},
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+            json={
+                "@type": "Folder",
+                "id": "myfolder",
+                "title": "My Folder",
+            },
+        )
+        self.assertEqual(403, response.status_code)
+        self.assertEqual(
+            response.json(),
+            {u'error': {u'message': u'Disallowed subobject type: Folder',
+                        u'type': u'Forbidden'}})


### PR DESCRIPTION
Salut @mpeeters 

lors de différents tests je me suis rendu compte qu'on reçoit parfois un message d'erreur inadéquat dans FolderPost car on "continue" même si par exemple il y a eu une erreur dans le FolderPost de plone.restapi et on a en fait l'erreur "suivante".

Est ce que tu peux regarder?

Merci!

Gauthier